### PR TITLE
Compatability with ggplot2 3.6.0

### DIFF
--- a/tests/testthat/test-plot_by_subject.R
+++ b/tests/testthat/test-plot_by_subject.R
@@ -89,7 +89,12 @@ test_that("top views created correctly via purrr::map", {
 test_that("top views wrangled correctly via tidyverse", {
   expect_match(top_all_plots$plot_type[[1]], "paths")
   expect_match(top_all_plots$subject[[5]], "device03")
-  expect_match(top_all_plots[[3]][[4]][["labels"]][["x"]], "position_width")
+  labels <- if ("get_labs" %in% getNamespaceExports("ggplot2")) {
+    ggplot2::get_labs(top_all_plots[[3]][[4]])
+  } else {
+    top_all_plots[[3]][[4]][["labels"]]
+  }
+  expect_match(labels[["x"]], "position_width")
 })
 
 #test that plotting works?
@@ -165,7 +170,12 @@ test_that("elev views created correctly via purrr::map", {
 test_that("elev views wrangled correctly via tidyverse", {
   expect_match(elev_all_plots$plot_type[[3]], "paths")
   expect_match(elev_all_plots$subject[[4]], "device02")
-  expect_match(elev_all_plots[[3]][[4]][["labels"]][["x"]], "position_height")
+  labels <- if ("get_labs" %in% getNamespaceExports("ggplot2")) {
+    ggplot2::get_labs(elev_all_plots[[3]][[4]])
+  } else {
+    elev_all_plots[[3]][[4]][["labels"]]
+  }
+  expect_match(labels[["x"]], "position_height")
 })
 
 ## Test that plotting works?


### PR DESCRIPTION
Hi there,

Apologies for not posting an issue first and for not following the PR template.
The ggplot2 package is planning an update for around May 2025 and a reverse dependency test identified a problem with the pathviewr package.
The details are explained in https://github.com/tidyverse/ggplot2/issues/6290, but essentially ggplot2 doesn't populate the `plot$labels` field before plot building anymore, which violates some test assumptions in this package.

This PR changes the tests to be compatible with both versions of ggplot2. 
You can test the changes yourself with the development version of ggplot2 (`pak::pak("tidyverse/ggplot2")`)

Best,
Teun